### PR TITLE
Only send payload to elasticsearch

### DIFF
--- a/src/coffee/elasticsearch.coffee
+++ b/src/coffee/elasticsearch.coffee
@@ -12,7 +12,7 @@ module.exports = (RED)->
 			es.create
 				index: config.index
 				type: config.documenttype
-				body: msg
+				body: msg.payload
 			, (error, response) ->
 				if (error)
 					node.error error, response


### PR DESCRIPTION
Fixes `Converting circular structure to JSON` errors caused by elasticsearch trying to `JSON.stringify(msg)`. 

All the other storage nodes only put in `msg.payload`
