### PR TITLE
Add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,6 @@
   "scripts": {
     "test": "grunt"
   },
-  "version": "0.0.2"
+  "version": "0.0.2",
+  "repository": "https://github.com/benediktarnold/node-red-contrib-elasticsearch.git"
 }


### PR DESCRIPTION
Helps people click through npmjs.org to get to the repo. 

Correction of #1 
